### PR TITLE
Show new contract address, fix Modal width

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -76,6 +76,22 @@ class App extends Component {
       return Array.prototype.map.call(new Uint8Array(buffer), x => ('00' + x.toString(16)).slice(-2)).join('');
     }
 
+    function getReceipt(thisObj, tx) {
+      thisObj.state.web3.eth.getTransactionReceipt(tx, (e, receipt) => {
+        if (e) throw(e)
+        if (receipt) {
+          thisObj.setState({
+            txModalOpen: true,
+            txReceipt: receipt,
+            TxStatusText: "Submit Transaction",
+            loading: false
+          })
+        } else {
+          setTimeout(getReceipt(thisObj, tx), 300)
+        }
+      })
+    }
+
 /*
     this.setState({
       txStatusText: "Transaction Pending"
@@ -141,19 +157,8 @@ class App extends Component {
 
     this.state.web3.eth.sendTransaction(txn, (e, tx) => {
       if (e) throw(e)
-      this.setState({loading: false})
 
-      let state = this.state
-      let onTx = this.onTx.bind(this)
-      let onTxDone = false
-      let blockCount = 0
-
-      this.setState({
-        txModalOpen: true,
-        txReceipt: tx,
-        TxStatusText: "Submit Transaction",
-        loading: false
-      })
+      getReceipt(this, tx)
 
     })
   }

--- a/app/src/components/TxModal.js
+++ b/app/src/components/TxModal.js
@@ -22,7 +22,7 @@ function getModalStyle() {
 const styles = theme => ({
   paper: {
     position: 'absolute',
-    width: theme.spacing.unit * 50,
+    width: theme.spacing.unit * 70,
     backgroundColor: theme.palette.background.paper,
     boxShadow: theme.shadows[5],
     padding: theme.spacing.unit * 4,
@@ -46,12 +46,13 @@ class SimpleModal extends React.Component {
   render() {
     const { classes } = this.props;
 
-    let createdAddress, txStatus = null
-    if (this.state.tx && this.state.tx.status) {
-      txStatus = "Status: " + this.state.tx.status == "1" ? "success" : "failure"
+    let createdAddress, transactionHash = null
+
+    if (this.props.txReceipt && this.props.txReceipt.contractAddress) {
+      createdAddress = "Contract Address: " + this.props.txReceipt.contractAddress;
     }
-    if (this.state.tx && this.state.tx.contractAddress) {
-      createdAddress = "Contract Address: " + this.state.tx.contractAddresss
+    if (this.props.txReceipt && this.props.txReceipt.transactionHash) {
+      transactionHash = this.props.txReceipt.transactionHash;
     }
 
     return (
@@ -63,10 +64,11 @@ class SimpleModal extends React.Component {
 			>
 				<div style={getModalStyle()} className={classes.paper}>
 					<Typography variant="subheading" id="simple-modal-description">
-            <p> Tx Receipt: { this.props.txReceipt } </p>
+            <p> Tx Receipt: { transactionHash } </p>
 					</Typography>
 					<SimpleModalWrapped />
-				</div>
+        <p>{createdAddress}</p>
+                                    </div>
 			</Modal>
     );
   }


### PR DESCRIPTION
This PR shows the new contract address as requested in https://github.com/ewasm/ewasm-studio/issues/19, it waits until the transaction is mined to get the transaction receipt, it shows the success message at the same time metamask the transaction is confirmed. Also fixes the modal message width.